### PR TITLE
 fix format not a string literal and no format arguments 

### DIFF
--- a/svg.c
+++ b/svg.c
@@ -1133,12 +1133,12 @@ int xctcl_svg(ClientData clientData, Tcl_Interp *interp,
 
    if (locobjc >= 2) {
       /* If there is a non-option argument, use it for the output filename */
-      sprintf(filename, Tcl_GetString(objv[1]));
+      sprintf(filename, "%s", Tcl_GetString(objv[1]));
    }
    else if (xobjs.pagelist[areawin->page]->pageinst->thisobject->name == NULL)
-      sprintf(filename, xobjs.pagelist[areawin->page]->filename);
+      sprintf(filename, "%s", xobjs.pagelist[areawin->page]->filename);
    else
-      sprintf(filename, xobjs.pagelist[areawin->page]->pageinst->thisobject->name);
+      sprintf(filename, "%s",  xobjs.pagelist[areawin->page]->pageinst->thisobject->name);
 
    pptr = strrchr(filename, '.');
    if (pptr != NULL)

--- a/tclxcircuit.c
+++ b/tclxcircuit.c
@@ -3877,7 +3877,7 @@ int xctcl_object(ClientData clientData, Tcl_Interp *interp,
       case NameIdx:
 	 if (nidx == 1 || areawin->selects == 0) {
 	    if (objc == 3) {
-	       sprintf(thisinst->thisobject->name, Tcl_GetString(objv[nidx + 2]));
+	       sprintf(thisinst->thisobject->name, "%s", Tcl_GetString(objv[nidx + 2]));
 	       checkname(thisinst->thisobject);
 	    }
 	    Tcl_AppendElement(interp, thisinst->thisobject->name);
@@ -7404,7 +7404,7 @@ int xctcl_page(ClientData clientData, Tcl_Interp *interp,
 
       case LoadIdx:
 	 TechReplaceSave();
-	 sprintf(_STR2, Tcl_GetString(objv[2 + nidx]));
+	 sprintf(_STR2, "%s", Tcl_GetString(objv[2 + nidx]));
 	 for (i = 3 + nidx; i < objc; i++) {
 	    argv = Tcl_GetString(objv[i]);
 	    if ((*argv == '-') && !strncmp(argv, "-repl", 5)) {
@@ -7490,7 +7490,7 @@ int xctcl_page(ClientData clientData, Tcl_Interp *interp,
 
 	 switch (importtype) {
 	    case XCircuitIdx:
-	       sprintf(_STR2, Tcl_GetString(objv[3 + nidx]));
+	       sprintf(_STR2, "%s", Tcl_GetString(objv[3 + nidx]));
 	       for (i = 4; i < objc; i++) {
 		  strcat(_STR2, ",");
 		  strcat(_STR2, Tcl_GetString(objv[i + nidx]));
@@ -7507,7 +7507,7 @@ int xctcl_page(ClientData clientData, Tcl_Interp *interp,
 		  Tcl_SetObjResult(interp, objPtr);
 		  return XcTagCallback(interp, objc, objv);
 	       }
-	       sprintf(_STR2, Tcl_GetString(objv[3 + nidx]));
+	       sprintf(_STR2, "%s", Tcl_GetString(objv[3 + nidx]));
 	       if (savepage != pageno) newpage(pageno);
 	       loadbackground();
 	       if (savepage != pageno) newpage(savepage);


### PR DESCRIPTION
```
svg.c:1136:7: error: format not a string literal and no format arguments [-Werror=format-security]
 1136 |       sprintf(filename, Tcl_GetString(objv[1]));
      |       ^~~~~~~
svg.c:1139:7: error: format not a string literal and no format arguments [-Werror=format-security]
 1139 |       sprintf(filename, xobjs.pagelist[areawin->page]->filename);
      |       ^~~~~~~
svg.c:1141:76: error: format not a string literal and no format arguments [-Werror=format-security]
 1141 |       sprintf(filename, xobjs.pagelist[areawin->page]->pageinst->thisobject->name);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```