### PR TITLE
Declare UDrawXAt in prototypes.h

### DIFF
--- a/prototypes.h
+++ b/prototypes.h
@@ -431,6 +431,7 @@ extern void UDrawSimpleLine(XPoint *, XPoint *);
 extern void UDrawLine(XPoint *, XPoint *);
 extern void UDrawCircle(XPoint *, u_char);
 extern void UDrawX(labelptr);
+extern void UDrawXAt(XPoint *);
 extern void UDrawXDown(labelptr);
 extern int  toplevelwidth(objinstptr, short *);
 extern int  toplevelheight(objinstptr, short *);


### PR DESCRIPTION
This avoids an implicit function declaration in functions.c for HAVE_CAIRO.  Future compilers will not accept such implicit function declarations by default, leading to a build failure.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
