### PR TITLE
here some changes which allowed me to get xcircuit running on Apple S…

### DIFF
--- a/Xw/Xw.h
+++ b/Xw/Xw.h
@@ -463,6 +463,18 @@ typedef struct _XwMenuMgrClassRec *XwMenuMgrWidgetClass;
 typedef struct _XwMenuMgrRec      *XwMenuMgrWidget;
 
 
+// TK: to satisfy gcc with std=c99 on MacOS:
+// avoid error: call to undeclared function 'XwRegisterConverters'; ISO C99 and later do not support implicit function declarations
+// function defined in Xw/ResConvert.c, used in Xw/Manager.c without declaration
+extern XwRegisterConverters();
+
+// this one is dirty: PopupMgr.c misses declaration of _XtPopup
+// copy&paste from /usr/X11/include/X11/TranslateI.h; file can't be included directly (internaly used file, many dependencies...)
+extern void _XtPopup(
+    Widget      /* widget */,
+    XtGrabKind  /* grab_kind */,
+    _XtBoolean  /* spring_loaded */
+);
 
 #endif
 /* DON'T ADD STUFF AFTER THIS #endif */

--- a/config.sub
+++ b/config.sub
@@ -3,7 +3,7 @@
 #   Copyright (C) 1992, 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001
 #   Free Software Foundation, Inc.
 
-timestamp='2001-08-13'
+timestamp='2023-11-04'
 
 # This file is (in principle) common to ALL GNU software.
 # The presence of a machine in this file suggests that SOME GNU software
@@ -276,6 +276,7 @@ case $basic_machine in
 	# Recognize the basic CPU types with company name.
 	580-* \
 	| a29k-* \
+	| aarch64-* \
 	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
 	| alphapca5[67]-* | arc-* \
 	| arm-*  | armbe-* | armle-* | armv*-* \


### PR DESCRIPTION
here some changes which allowed me to get xcircuit running on Apple Silicon
Makefiles prepared with: ./configure --with-cairo=no
This allowed me to load & edit my schematics with MacOS 14.0 on a M2 processor again - hurray
Schematics are partly from mid 199*s - I'm a long term user! :)
