### PR TITLE
Fixes for GCC 15

### DIFF
--- a/elements.c
+++ b/elements.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 #ifndef XC_WIN32
 #include <X11/Intrinsic.h>
@@ -53,8 +54,6 @@ extern colorindex *colorlist;
 #if !defined(HAVE_CAIRO)
 extern Pixmap dbuf;
 #endif
-
-extern double atan2();
 
 /*------------------------------------------------------------------------*/
 /* Declarations of global variables                                       */

--- a/events.c
+++ b/events.c
@@ -2195,8 +2195,9 @@ int functiondispatch(int function, short value, int x, int y)
 	 exchange();
 	 break;
       case XCF_Library_Move:
-	 /* Don't allow from library directory.  Then fall through to XCF_Move */
+	 /* Don't allow from library directory. */
 	 if (areawin->topinstance == xobjs.libtop[LIBLIB]) break;
+	 /* fall through */
       case XCF_Move:
 	 if (areawin->selects == 0) {
 	    was_preselected = FALSE;

--- a/events.c
+++ b/events.c
@@ -4479,7 +4479,7 @@ short *xc_undelete(objinstptr thisinstance, objectptr delobj, short mode,
 
 void printname(objectptr curobject)
 {
-   char editstr[10], pagestr[10];
+   char editstr[10], pagestr[30];
    short ispage;
 
 #ifndef TCL_WRAPPER

--- a/files.c
+++ b/files.c
@@ -2552,7 +2552,7 @@ u_char *find_delimiter(u_char *fstring)
 	 /* An even number of backslashes indicates that the nearest backslash
 	  * is not an escape, but a backslash.
 	  */
-	 char *bsrch;
+	 u_char *bsrch;
 	 int bscnt = 0;
 
 	 for (bsrch = search - 1; bsrch >= fstring && *bsrch == '\\'; bsrch++) {

--- a/functions.c
+++ b/functions.c
@@ -907,8 +907,7 @@ void InvertCTM(Matrix *ctm)
 
 /*------------------------------------------------------------------------*/
 
-void UCopyCTM(fctm, tctm)
-   Matrix *fctm, *tctm;
+void UCopyCTM(Matrix *fctm, Matrix *tctm)
 {
    tctm->a = fctm->a;
    tctm->b = fctm->b;

--- a/tkSimple.c
+++ b/tkSimple.c
@@ -133,12 +133,13 @@ static int		SimpleWidgetObjCmd _ANSI_ARGS_((ClientData clientData,
  */
 
 int
-Tk_SimpleObjCmd(clientData, interp, objc, objv)
-    ClientData clientData;	/* Main window associated with
+Tk_SimpleObjCmd(
+    ClientData clientData,	/* Main window associated with
 				 * interpreter. */
-    Tcl_Interp *interp;		/* Current interpreter. */
-    int objc;			/* Number of arguments. */
-    Tcl_Obj *CONST objv[];	/* Argument objects. */
+    Tcl_Interp *interp,		/* Current interpreter. */
+    int objc,			/* Number of arguments. */
+    Tcl_Obj *CONST objv[]	/* Argument objects. */
+    )
 {
     Tk_Window tkwin = (Tk_Window) clientData;
     Simple *simplePtr;
@@ -262,11 +263,12 @@ Tk_SimpleObjCmd(clientData, interp, objc, objv)
  */
 
 static int
-SimpleWidgetObjCmd(clientData, interp, objc, objv)
-    ClientData clientData;	/* Information about simple widget. */
-    Tcl_Interp *interp;		/* Current interpreter. */
-    int objc;			/* Number of arguments. */
-    Tcl_Obj *CONST objv[];	/* Argument objects. */
+SimpleWidgetObjCmd(
+    ClientData clientData,	/* Information about simple widget. */
+    Tcl_Interp *interp,		/* Current interpreter. */
+    int objc,			/* Number of arguments. */
+    Tcl_Obj *CONST objv[]	/* Argument objects. */
+    )
 {
     static char *simpleOptions[] = {
 	"cget", "configure", (char *) NULL
@@ -361,8 +363,9 @@ SimpleWidgetObjCmd(clientData, interp, objc, objv)
  */
 
 static void
-DestroySimple(memPtr)
-    char *memPtr;		/* Info about simple widget. */
+DestroySimple(
+    char *memPtr		/* Info about simple widget. */
+    )
 {
     register Simple *simplePtr = (Simple *) memPtr;
 
@@ -397,13 +400,14 @@ DestroySimple(memPtr)
  */
 
 static int
-ConfigureSimple(interp, simplePtr, objc, objv, flags)
-    Tcl_Interp *interp;		/* Used for error reporting. */
-    register Simple *simplePtr;	/* Information about widget;  may or may
+ConfigureSimple(
+    Tcl_Interp *interp,		/* Used for error reporting. */
+    register Simple *simplePtr,	/* Information about widget;  may or may
 				 * not already have values for some fields. */
-    int objc;			/* Number of valid entries in objv. */
-    Tcl_Obj *CONST objv[];	/* Arguments. */
-    int flags;			/* Flags to pass to Tk_ConfigureWidget. */
+    int objc,			/* Number of valid entries in objv. */
+    Tcl_Obj *CONST objv[],	/* Arguments. */
+    int flags			/* Flags to pass to Tk_ConfigureWidget. */
+    )
 {
   /* char *oldMenuName; (jdk) */
     
@@ -445,9 +449,10 @@ ConfigureSimple(interp, simplePtr, objc, objv, flags)
  */
 
 static void
-SimpleEventProc(clientData, eventPtr)
-    ClientData clientData;	/* Information about window. */
-    register XEvent *eventPtr;	/* Information about event. */
+SimpleEventProc(
+    ClientData clientData,	/* Information about window. */
+    register XEvent *eventPtr	/* Information about event. */
+    )
 {
     register Simple *simplePtr = (Simple *) clientData;
 
@@ -502,8 +507,9 @@ SimpleEventProc(clientData, eventPtr)
  */
 
 static void
-SimpleCmdDeletedProc(clientData)
-    ClientData clientData;	/* Pointer to widget record for widget. */
+SimpleCmdDeletedProc(
+    ClientData clientData	/* Pointer to widget record for widget. */
+    )
 {
     Simple *simplePtr = (Simple *) clientData;
     Tk_Window tkwin = simplePtr->tkwin;

--- a/xcircdnull.c
+++ b/xcircdnull.c
@@ -18,8 +18,7 @@
 /*----------------------------------------------------------------------*/
 
 int
-xcircuit_AppInit(interp)
-    Tcl_Interp *interp;
+xcircuit_AppInit(Tcl_Interp *interp)
 {
     if (Tcl_Init(interp) == TCL_ERROR) {
 	return TCL_ERROR;
@@ -43,9 +42,7 @@ xcircuit_AppInit(interp)
 /*----------------------------------------------------------------------*/
 
 int
-main(argc, argv)
-   int argc;
-   char **argv;
+main(int argc, char **argv)
 {
     Tcl_Main(argc, argv, xcircuit_AppInit);
     return 0;

--- a/xcircexec.c
+++ b/xcircexec.c
@@ -45,8 +45,7 @@
 /*----------------------------------------------------------------------*/
 
 int
-xcircuit_AppInit(interp)
-    Tcl_Interp *interp;
+xcircuit_AppInit(Tcl_Interp *interp)
 {
     if (Tcl_Init(interp) == TCL_ERROR) {
 	return TCL_ERROR;
@@ -69,9 +68,7 @@ xcircuit_AppInit(interp)
 /*----------------------------------------------------------------------*/
 
 int
-main(argc, argv)
-   int argc;
-   char **argv;
+main(int argc, char **argv)
 {
     Tk_Main(argc, argv, xcircuit_AppInit);
     return 0;

--- a/xcircuit.c
+++ b/xcircuit.c
@@ -1426,8 +1426,9 @@ static Tcl_ObjType tclHandleType = {
 /*----------------------------------------------------------------------*/
 
 static void
-UpdateStringOfHandle(objPtr)
-    Tcl_Obj *objPtr;   /* Int object whose string rep to update. */
+UpdateStringOfHandle(
+    Tcl_Obj *objPtr	/* Int object whose string rep to update. */
+    )
 {
     char buffer[TCL_INTEGER_SPACE];
     int len;
@@ -1443,9 +1444,10 @@ UpdateStringOfHandle(objPtr)
 /*----------------------------------------------------------------------*/
 
 static int
-SetHandleFromAny(interp, objPtr)
-    Tcl_Interp *interp;         /* Used for error reporting if not NULL. */
-    Tcl_Obj *objPtr;   /* The object to convert. */
+SetHandleFromAny(
+    Tcl_Interp *interp,	/* Used for error reporting if not NULL. */
+    Tcl_Obj *objPtr	/* The object to convert. */
+    )
 {  
     Tcl_ObjType *oldTypePtr = (Tcl_ObjType *)objPtr->typePtr;
     char *string, *end;
@@ -1577,8 +1579,9 @@ nexthier:
 /*----------------------------------------------------------------------*/
 
 Tcl_Obj *
-Tcl_NewHandleObj(optr)
-    void *optr;      /* Int used to initialize the new object. */
+Tcl_NewHandleObj(
+    void *optr	/* Int used to initialize the new object. */
+    )
 {
     Tcl_Obj *objPtr;
 
@@ -1593,10 +1596,11 @@ Tcl_NewHandleObj(optr)
 /*----------------------------------------------------------------------*/
 
 int
-Tcl_GetHandleFromObj(interp, objPtr, handlePtr)
-    Tcl_Interp *interp;		/* Used for error reporting if not NULL. */
-    Tcl_Obj *objPtr;	/* The object from which to get a int. */
-    void **handlePtr;	/* Place to store resulting int. */
+Tcl_GetHandleFromObj(
+    Tcl_Interp *interp,	/* Used for error reporting if not NULL. */
+    Tcl_Obj *objPtr,	/* The object from which to get a int. */
+    void **handlePtr	/* Place to store resulting int. */
+    )
 {
     long l;
     int result;


### PR DESCRIPTION
These patches fix one compile error and several warnings when building with GCC 15, which defaults to the C23 language standard.

You also need #18 to add the missing prototype for `UDrawAt` - that's been a compile error since GCC 14.

I've only done this for `--with-tk` mode - the Xw code has lots of old-style function declarations which would benefit from similar treatment.